### PR TITLE
Update version of EBS with running node js

### DIFF
--- a/chapter16/template.yaml
+++ b/chapter16/template.yaml
@@ -110,7 +110,7 @@ Resources:
     Properties:
       ApplicationName: !Ref EBWorkerApplication
       Description: 'Imagery worker: AWS in Action: chapter 16'
-      SolutionStackName: '64bit Amazon Linux 2018.03 v4.10.2 running Node.js'
+      SolutionStackName: '64bit Amazon Linux 2018.03 v4.14.1 running Node.js'
       OptionSettings:
       - Namespace: 'aws:autoscaling:launchconfiguration'
         OptionName: 'EC2KeyName'
@@ -223,7 +223,7 @@ Resources:
     Properties:
       ApplicationName: !Ref EBServerApplication
       Description: 'Imagery server: AWS in Action: chapter 16'
-      SolutionStackName: '64bit Amazon Linux 2018.03 v4.10.2 running Node.js'
+      SolutionStackName: '64bit Amazon Linux 2018.03 v4.14.1 running Node.js'
       OptionSettings:
       - Namespace: 'aws:autoscaling:asg'
         OptionName: 'MinSize'


### PR DESCRIPTION
Based on this below link I updated the version otherwise it was failing on creation of the stack with a rollback error,
https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html#platforms-supported.nodejs

Please run `yamllint folder/template.yaml` and `aws cloudformation validate-template --template-body file://folder/template.yaml` before
